### PR TITLE
handle dates && test

### DIFF
--- a/src/dnull.test.ts
+++ b/src/dnull.test.ts
@@ -12,6 +12,10 @@ it("works on arrays", () => {
   expect(dnull([1, 2, null])).toEqual([1, 2, undefined]);
 });
 
+it("works on dates", () => {
+  expect(dnull(new Date("01-01-2000"))).toEqual(new Date("01-01-2000"));
+});
+
 it("works on nested structures", () => {
   const obj = {
     name: "john",

--- a/src/dnull.ts
+++ b/src/dnull.ts
@@ -13,6 +13,7 @@ export type DNull<T> = T extends null
 
 export const dnull = <T>(src: T): DNull<T> => {
   if (src === null) return undefined as any;
+  if (src instanceof Date) return src as any;
   if (isPlainObject(src))
     return Object.fromEntries(
       Object.entries(src).map(([key, value]) => [key, dnull(value)]),


### PR DESCRIPTION
Previously a date object was falling into the `isPlainObject` branch - and returning `{}` (as seen in the new test added).  By adding this additional `src instanceof Date` check - we're able to short-circuit and keep date objects in-tact